### PR TITLE
Added checks to prevent errors

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,14 @@
+In this version, I added checks to eliminate the following
+three errors:
+
+1. chmod: cannot access '/boot/grub2/grub.cfg': No such file or directory
+   Apparently, grub.cfg doesn't exist if your on an EFI
+   system rather than a BIOS system
+
+2. chmod: missing operand after ‘a+t’
+   I received this error while the script was checking
+   for the sticky bit on world-writable directories.
+   I didn't have any world-writable directories.
+
+3. grep: /etc/modprobe.d/ipv6.conf: No such file or directory
+   ipv6.conf didn't exist

--- a/rhel8.sh
+++ b/rhel8.sh
@@ -282,7 +282,10 @@ chmod 644 /etc/passwd
 chmod 000 /etc/shadow
 chmod 000 /etc/gshadow
 chmod 644 /etc/group
-chmod 600 /boot/grub2/grub.cfg
+# grub.cfg won't exist on an EFI system
+if [ -f /boot/grub2/grub.cfg ]; then
+	chmod 600 /boot/grub2/grub.cfg
+fi
 chmod 600 /etc/rsyslog.conf
 chown root:root /etc/passwd
 chown root:root /etc/shadow
@@ -290,7 +293,7 @@ chown root:root /etc/gshadow
 chown root:root /etc/group
 
 echo "Setting Sticky Bit on All World-Writable Directories..."
-df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -type d \( -perm -0002 -a ! -perm -1000 \) 2>/dev/null | xargs chmod a+t >> $AUDITDIR/sticky_on_world_$TIME.log
+df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -type d \( -perm -0002 -a ! -perm -1000 \) 2>/dev/null | xargs -r chmod a+t >> $AUDITDIR/sticky_on_world_$TIME.log
 
 echo "Searching for world writable files..."
 df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -type f -perm -0002 >> $AUDITDIR/world_writable_files_$TIME.log
@@ -591,7 +594,7 @@ cp /etc/sysconfig/network $AUDITDIR/network_$TIME.bak
 for i in "NETWORKING_IPV6=no" "IPV6INIT=no"; do
   [[ `egrep -q "^$i" /etc/sysconfig/network` ]] || echo "$i" >> /etc/sysconfig/network
 done
-[[ `egrep -q "options ipv6 disable=1" /etc/modprobe.d/ipv6.conf` ]] || echo "options ipv6 disable=1" >> /etc/modprobe.d/ipv6.conf
+[ -f /etc/modprobe.d/ipv6.conf ] && `egrep -q "options ipv6 disable=1" /etc/modprobe.d/ipv6.conf` || echo "options ipv6 disable=1" >> /etc/modprobe.d/ipv6.conf
 
 echo "Disabling WLAN interfaces..."
 nmcli radio all off


### PR DESCRIPTION
This script is a huge help in bringing a system into compliance with the CIS benchmark. Thank you for that! When I ran it on my first system, I received the errors noted in the changelog. They were benign but I don't like errors in this sort of output because it causes false positives when I grep the output to see if there's anything I need to address. Not a big deal on one or two systems but a huge deal on 100 or 200. The changes are minor but keep the errors from appearing in a way that shouldn't compromise the operation of the script.